### PR TITLE
Add Java NATS examples repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The must haves
 - [NATS By Example](https://natsbyexample.com) - An evolving collection of runnable, cross-client reference examples for NATS
 - [Synadia Youtube Channel](https://www.youtube.com/@SynadiaCommunications) - Growing list of videos NATS, covering wide variety of topics
 - [NATS.fm](https://www.synadia.com/podcast) - Podcast dedicated to NATS, hosted by David Gee and Byron Ruth
+- [Java NATS examples](https://github.com/nats-io/java-nats-examples/tree/main) - Collection of Java (and Kotlin) examples
 
 ## Clients
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The must haves
 
 - [NATS Server](http://github.com/nats-io/nats-server) - The only binary you need to run single server, clusters, super-clusters and leaf nodes
 - [NATS CLI](http://github.com/nats-io/natscli) - CLI for managing, interacting, benchmarking and debugging NATS
+- [Nats-top](https://github.com/nats-io/nats-top) - CLI tool for real-time monitoring of the nats-server
 
 ## Docs and learning materials
 
@@ -79,7 +80,7 @@ Tools useful when working with NATS in Kubernetes ecosystem.
 
 - [Surveyor](http://github.com/nats-io/nats-surveyor) - Simplified NATS observability
 - [Prometheus NATS exporter](https://github.com/nats-io/prometheus-nats-exporter) - Export NATS Server metrics to Prometheus
-- [NATS dashboard](https://natsdashboard.com/) - GUI for real-time monitoring of nats-server (exposes Core NATS plus JetStream information)
+- [NATS dashboard](https://natsdashboard.com/) - GUI for real-time monitoring of nats-server (exposes the same information you get out of `nats-top` plus JetStream information)
 
 ## Connectors and Integrations
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The must haves
 
 - [NATS Server](http://github.com/nats-io/nats-server) - The only binary you need to run single server, clusters, super-clusters and leaf nodes
 - [NATS CLI](http://github.com/nats-io/natscli) - CLI for managing, interacting, benchmarking and debugging NATS
-- [Nats-top](https://github.com/nats-io/nats-top) - CLI tool for real-time monitoring of the nats-server
 
 ## Docs and learning materials
 
@@ -80,7 +79,7 @@ Tools useful when working with NATS in Kubernetes ecosystem.
 
 - [Surveyor](http://github.com/nats-io/nats-surveyor) - Simplified NATS observability
 - [Prometheus NATS exporter](https://github.com/nats-io/prometheus-nats-exporter) - Export NATS Server metrics to Prometheus
-- [NATS dashboard](https://natsdashboard.com/) - GUI for real-time monitoring of nats-server (exposes the same information you get out of `nats-top` plus JetStream information)
+- [NATS dashboard](https://natsdashboard.com/) - GUI for real-time monitoring of nats-server (exposes Core NATS plus JetStream information)
 
 ## Connectors and Integrations
 


### PR DESCRIPTION
Adds a link to the separate Java NATS examples repo as it contains a pretty exhaustive set of Java examples (and it's easy to not know it exists since it's a separate repo from nats.java)